### PR TITLE
dont store provider params for now, refs #8

### DIFF
--- a/providers/job.go
+++ b/providers/job.go
@@ -11,6 +11,6 @@ type Job struct {
 	ProviderID string `json:"provider_id"`
 	Provider   string `json:"provider"`
 	//  Datastore doesnt support  maps by default
-	//	ProviderMetadata map[string]string `json:"provider_params"`
-	CreatedAt time.Time `json:"created_at"`
+	ProviderParams map[string]string `datastore:"-" json:"provider_params"`
+	CreatedAt      time.Time         `json:"created_at"`
 }

--- a/providers/threeplay.go
+++ b/providers/threeplay.go
@@ -67,10 +67,11 @@ func (c *ThreePlayProvider) GetJob(id string) (*Job, error) {
 // DispatchJob sends a video file to 3play for transcription and captions generation
 func (c *ThreePlayProvider) DispatchJob(job Job) (Job, error) {
 	jobLogger := c.logger.WithFields(log.Fields{"JobID": job.ID, "Provider": job.Provider})
-	jobLogger.Info("Dispatching job to 3Play")
-	// TODO: we need to parse job.ProviderParams to query
-	query, _ := url.ParseQuery("for_asr=1")
+	query := url.Values{}
 
+	for k, v := range job.ProviderParams {
+		query.Add(k, v)
+	}
 	fileID, err := c.UploadFileFromURL(job.MediaURL, query)
 
 	if err != nil {

--- a/service/client.go
+++ b/service/client.go
@@ -63,7 +63,7 @@ func (c Client) DispatchJob(job providers.Job) (providers.Job, error) {
 	jobLogger.Info("Storing job in DB")
 	_, err = c.DB.StoreJob(job)
 	if err != nil {
-		jobLogger.Error("Error storing job in DB")
+		jobLogger.Error("Error storing job in DB", err)
 		return providers.Job{}, errors.New("Error storing Job")
 	}
 	return job, err


### PR DESCRIPTION
with this we can use:
`curl -XPOST -d'{"media_url":"https://vp.nyt.com/video/2017/05/11/72456_1_fbi-director_wg_360p.mp4", "scoop_id": "123", "provider": "3play", "provider_params": {"for_asr": "1"}}' localhost:8000/jobs`

and whatever is inside provider_params gets passed to our threeplay client
the down side is that we dont store the params used to dispatch the job