### PR TITLE
Tie jobs to parent id

### DIFF
--- a/database/datastore.go
+++ b/database/datastore.go
@@ -75,10 +75,10 @@ func (d *DatastoreDatabase) GetJob(id string) (providers.Job, error) {
 }
 
 // GetJobs retrieves all jobs in database
-func (d *DatastoreDatabase) GetJobs() ([]providers.Job, error) {
-	query := datastore.NewQuery(d.kind).Namespace(d.namespace)
+func (d *DatastoreDatabase) GetJobs(parentID string) ([]providers.Job, error) {
 	var jobs []providers.Job
 	ctx := context.Background()
+	query := datastore.NewQuery(d.kind).Namespace(d.namespace).Filter("ParentID =", parentID)
 	_, err := d.client.GetAll(ctx, query, &jobs)
 	if err != nil {
 		return nil, err

--- a/database/db.go
+++ b/database/db.go
@@ -8,5 +8,5 @@ type DB interface {
 	UpdateJob(string, providers.Job) error
 	GetJob(string) (providers.Job, error)
 	DeleteJob(string) error
-	GetJobs() ([]providers.Job, error)
+	GetJobs(string) ([]providers.Job, error)
 }

--- a/database/memory.go
+++ b/database/memory.go
@@ -66,14 +66,16 @@ func (db *MemoryDatabase) DeleteJob(id string) error {
 	return nil
 }
 
-// GetJobs Returns all Jobs stored
-func (db *MemoryDatabase) GetJobs() ([]providers.Job, error) {
+// GetJobs Returns all Jobs stored for the same ParentID
+func (db *MemoryDatabase) GetJobs(parentID string) ([]providers.Job, error) {
 	db.mtx.Lock()
 	defer db.mtx.Unlock()
 
-	jobList := make([]providers.Job, len(db.jobs))
+	var jobList []providers.Job
 	for _, job := range db.jobs {
-		jobList = append(jobList, job)
+		if parentID == job.ParentID {
+			jobList = append(jobList, job)
+		}
 	}
 
 	return jobList, nil

--- a/providers/job.go
+++ b/providers/job.go
@@ -9,6 +9,7 @@ import (
 // Job representation of a captions job
 type Job struct {
 	ID       string `json:"id"`
+	ParentID string `json:"parent_id"`
 	MediaURL string `json:"media_url"`
 	Status   string `json:"status"`
 	// this should be in the ProviderParams

--- a/service/client.go
+++ b/service/client.go
@@ -12,14 +12,14 @@ import (
 type Client struct {
 	Providers map[string]providers.Provider
 	DB        database.DB
-	logger    *log.Logger
+	Logger    *log.Logger
 }
 
 // GetJobs gets all jobs associated with a ParentID
 func (c Client) GetJobs(parentID string) ([]providers.Job, error) {
 	jobs, err := c.DB.GetJobs(parentID)
 	if err != nil {
-		c.logger.Error("Error loading jobs from DB", parentID)
+		c.Logger.Error("Error loading jobs from DB", parentID)
 		return nil, err
 	}
 	return jobs, nil
@@ -29,16 +29,16 @@ func (c Client) GetJobs(parentID string) ([]providers.Job, error) {
 func (c Client) GetJob(jobID string) (providers.Job, error) {
 	job, err := c.DB.GetJob(jobID)
 	if err != nil {
-		c.logger.Error("Could not find Job in database")
+		c.Logger.Error("Could not find Job in database")
 		return job, err
 	}
 
-	jobLogger := c.logger.WithFields(log.Fields{"JobID": jobID, "Provider": job.Provider})
+	jobLogger := c.Logger.WithFields(log.Fields{"JobID": jobID, "Provider": job.Provider})
 	provider := c.Providers[job.Provider]
 	jobLogger.Info("Fetching job from Provider")
 	providerJob, err := provider.GetJob(job.ProviderID)
 	if err != nil {
-		jobLogger.Error("error gettting job from provider", err)
+		jobLogger.Error("error getting job from provider", err)
 		return job, err
 	}
 
@@ -56,7 +56,7 @@ func (c Client) GetJob(jobID string) (providers.Job, error) {
 // DispatchJob dispatches a Job given an existing Provider
 func (c Client) DispatchJob(job providers.Job) (providers.Job, error) {
 	provider := c.Providers[job.Provider]
-	jobLogger := c.logger.WithFields(log.Fields{"JobID": job.ID, "Provider": job.Provider})
+	jobLogger := c.Logger.WithFields(log.Fields{"JobID": job.ID, "Provider": job.Provider})
 	if provider == nil {
 		jobLogger.Error("Provider not found")
 		return providers.Job{}, errors.New("Provider not found")

--- a/service/client_test.go
+++ b/service/client_test.go
@@ -11,7 +11,7 @@ import (
 func TestGetJob(t *testing.T) {
 	service, client := createCaptionsService()
 	assert := assert.New(t)
-	service.AddProvider(FakeProvider{logger: log.New()})
+	service.AddProvider(fakeProvider{logger: log.New()})
 	job := providers.Job{
 		ID:       "123",
 		MediaURL: "http://vp.nyt.com/video.mp4",

--- a/service/client_test.go
+++ b/service/client_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestGetJob(t *testing.T) {
-	service, client := CreateCaptionsService()
+	service, client := createCaptionsService()
 	assert := assert.New(t)
 	service.AddProvider(FakeProvider{logger: log.New()})
 	job := providers.Job{
@@ -24,7 +24,7 @@ func TestGetJob(t *testing.T) {
 }
 
 func TestDispatchJobNoProvider(t *testing.T) {
-	_, client := CreateCaptionsService()
+	_, client := createCaptionsService()
 	_, err := client.DispatchJob(providers.Job{Provider: "wrong-provider"})
 	assert.Equal(t, "Provider not found", err.Error())
 }

--- a/service/client_test.go
+++ b/service/client_test.go
@@ -1,0 +1,30 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/NYTimes/video-captions-api/providers"
+	log "github.com/Sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetJob(t *testing.T) {
+	service, client := CreateCaptionsService()
+	assert := assert.New(t)
+	service.AddProvider(FakeProvider{logger: log.New()})
+	job := providers.Job{
+		ID:       "123",
+		MediaURL: "http://vp.nyt.com/video.mp4",
+		Provider: "test-provider",
+	}
+	client.DB.StoreJob(job)
+	resultJob, _ := client.GetJob(job.ID)
+	assert.Equal(job.ID, resultJob.ID)
+	assert.Equal(job.MediaURL, resultJob.MediaURL)
+}
+
+func TestDispatchJobNoProvider(t *testing.T) {
+	_, client := CreateCaptionsService()
+	_, err := client.DispatchJob(providers.Job{Provider: "wrong-provider"})
+	assert.Equal(t, "Provider not found", err.Error())
+}

--- a/service/job.go
+++ b/service/job.go
@@ -26,11 +26,11 @@ func (s *CaptionsService) GetJobs(r *http.Request) (int, interface{}, error) {
 func (s *CaptionsService) GetJob(r *http.Request) (int, interface{}, error) {
 	id := web.Vars(r)["id"]
 	// TODO: on the 3play client, we should look at the errors field and check for not_found errors at least
-	file, err := s.client.GetJob(id)
+	job, err := s.client.GetJob(id)
 	if err != nil {
 		return http.StatusNotFound, nil, err
 	}
-	return http.StatusOK, file, nil
+	return http.StatusOK, job, nil
 }
 
 // CreateJob create a Job

--- a/service/job.go
+++ b/service/job.go
@@ -12,7 +12,7 @@ import (
 	"github.com/satori/go.uuid"
 )
 
-// GetJobs from Provider given a Job id
+// GetJobs returns all the Jobs associated with a ParentID
 func (s *CaptionsService) GetJobs(r *http.Request) (int, interface{}, error) {
 	parentID := web.Vars(r)["id"]
 	jobs, err := s.client.GetJobs(parentID)
@@ -22,7 +22,7 @@ func (s *CaptionsService) GetJobs(r *http.Request) (int, interface{}, error) {
 	return http.StatusOK, jobs, nil
 }
 
-// GetJobs from Provider given a Job id
+// GetJob returns a Job given its ID
 func (s *CaptionsService) GetJob(r *http.Request) (int, interface{}, error) {
 	id := web.Vars(r)["id"]
 	// TODO: on the 3play client, we should look at the errors field and check for not_found errors at least

--- a/service/job.go
+++ b/service/job.go
@@ -8,11 +8,21 @@ import (
 
 	"github.com/NYTimes/gizmo/web"
 	"github.com/NYTimes/video-captions-api/providers"
-	"github.com/satori/go.uuid"
 	log "github.com/Sirupsen/logrus"
+	"github.com/satori/go.uuid"
 )
 
-// GetJob from Provider given a Job id
+// GetJobs from Provider given a Job id
+func (s *CaptionsService) GetJobs(r *http.Request) (int, interface{}, error) {
+	parentID := web.Vars(r)["id"]
+	jobs, err := s.client.GetJobs(parentID)
+	if err != nil {
+		return http.StatusNotFound, nil, err
+	}
+	return http.StatusOK, jobs, nil
+}
+
+// GetJobs from Provider given a Job id
 func (s *CaptionsService) GetJob(r *http.Request) (int, interface{}, error) {
 	id := web.Vars(r)["id"]
 	// TODO: on the 3play client, we should look at the errors field and check for not_found errors at least
@@ -27,8 +37,8 @@ func (s *CaptionsService) GetJob(r *http.Request) (int, interface{}, error) {
 func (s *CaptionsService) CreateJob(r *http.Request) (int, interface{}, error) {
 	requestLogger := logger.WithFields(log.Fields{
 		"Handler": "CreateJob",
-		"Method": r.Method,
-		"URI": r.RequestURI,
+		"Method":  r.Method,
+		"URI":     r.RequestURI,
 	})
 	var job providers.Job
 	data, err := ioutil.ReadAll(r.Body)
@@ -50,8 +60,8 @@ func (s *CaptionsService) CreateJob(r *http.Request) (int, interface{}, error) {
 		return http.StatusBadRequest, nil, errors.New("Please provide a media_url")
 	}
 
+	job.ParentID = job.ID
 	job.ID = uuid.NewV4().String()
-
 	job, err = s.client.DispatchJob(job)
 	if err != nil {
 		return http.StatusInternalServerError, err, err

--- a/service/job_test.go
+++ b/service/job_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestCreateJob(t *testing.T) {
 	assert := assert.New(t)
-	service, client := CreateCaptionsService()
+	service, client := createCaptionsService()
 	service.AddProvider(FakeProvider{logger: client.Logger})
 	job := providers.Job{
 		ID:       "123",
@@ -32,7 +32,7 @@ func TestCreateJob(t *testing.T) {
 
 func TestCreateJobNoMediaURL(t *testing.T) {
 	assert := assert.New(t)
-	service, client := CreateCaptionsService()
+	service, client := createCaptionsService()
 	service.AddProvider(FakeProvider{logger: client.Logger})
 	job := providers.Job{
 		ID:       "123",
@@ -49,7 +49,7 @@ func TestCreateJobNoMediaURL(t *testing.T) {
 
 func TestCreateJobDispatchError(t *testing.T) {
 	assert := assert.New(t)
-	service, client := CreateCaptionsService()
+	service, client := createCaptionsService()
 	service.AddProvider(BrokenProvider{logger: client.Logger})
 	job := providers.Job{
 		ID:       "123",
@@ -66,7 +66,7 @@ func TestCreateJobDispatchError(t *testing.T) {
 
 func TestCreateJobInvalidBody(t *testing.T) {
 	assert := assert.New(t)
-	service, client := CreateCaptionsService()
+	service, client := createCaptionsService()
 	service.AddProvider(FakeProvider{logger: client.Logger})
 	r, _ := http.NewRequest("POST", "/captions", bytes.NewReader([]byte("not json")))
 	status, resultJob, err := service.CreateJob(r)
@@ -78,7 +78,7 @@ func TestCreateJobInvalidBody(t *testing.T) {
 
 func TestGetJob404(t *testing.T) {
 	assert := assert.New(t)
-	service, _ := CreateCaptionsService()
+	service, _ := createCaptionsService()
 	r, _ := http.NewRequest("GET", "/jobs/404", nil)
 	status, _, err := service.GetJob(r)
 	assert.Equal(status, 404)

--- a/service/job_test.go
+++ b/service/job_test.go
@@ -1,0 +1,86 @@
+package service
+
+import (
+	"testing"
+
+	"bytes"
+	"encoding/json"
+	"net/http"
+
+	"github.com/NYTimes/video-captions-api/providers"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCreateJob(t *testing.T) {
+	assert := assert.New(t)
+	service, client := CreateCaptionsService()
+	service.AddProvider(FakeProvider{logger: client.Logger})
+	job := providers.Job{
+		ID:       "123",
+		MediaURL: "http://vp.nyt.com/video.mp4",
+		Provider: "test-provider",
+	}
+	jobBytes, _ := json.Marshal(job)
+	r, _ := http.NewRequest("POST", "/captions", bytes.NewReader(jobBytes))
+	status, resultJob, err := service.CreateJob(r)
+	job = resultJob.(providers.Job)
+	assert.Nil(err)
+	assert.Equal(201, status)
+	assert.Equal(job.ParentID, "123")
+}
+
+func TestCreateJobNoMediaURL(t *testing.T) {
+	assert := assert.New(t)
+	service, client := CreateCaptionsService()
+	service.AddProvider(FakeProvider{logger: client.Logger})
+	job := providers.Job{
+		ID:       "123",
+		Provider: "test-provider",
+	}
+	jobBytes, _ := json.Marshal(job)
+	r, _ := http.NewRequest("POST", "/captions", bytes.NewReader(jobBytes))
+	status, resultJob, err := service.CreateJob(r)
+	assert.NotNil(err)
+	assert.Equal("Please provide a media_url", err.Error())
+	assert.Nil(resultJob)
+	assert.Equal(400, status)
+}
+
+func TestCreateJobDispatchError(t *testing.T) {
+	assert := assert.New(t)
+	service, client := CreateCaptionsService()
+	service.AddProvider(BrokenProvider{logger: client.Logger})
+	job := providers.Job{
+		ID:       "123",
+		MediaURL: "http://vp.nyt.com/video.mp4",
+		Provider: "broken-provider",
+	}
+	jobBytes, _ := json.Marshal(job)
+	r, _ := http.NewRequest("POST", "/captions", bytes.NewReader(jobBytes))
+	status, _, err := service.CreateJob(r)
+	assert.NotNil(err)
+	assert.Equal("Error dispatching Job", err.Error())
+	assert.Equal(500, status)
+}
+
+func TestCreateJobInvalidBody(t *testing.T) {
+	assert := assert.New(t)
+	service, client := CreateCaptionsService()
+	service.AddProvider(FakeProvider{logger: client.Logger})
+	r, _ := http.NewRequest("POST", "/captions", bytes.NewReader([]byte("not json")))
+	status, resultJob, err := service.CreateJob(r)
+	assert.NotNil(err)
+	assert.Equal("Malformed parameters", err.Error())
+	assert.Nil(resultJob)
+	assert.Equal(400, status)
+}
+
+func TestGetJob404(t *testing.T) {
+	assert := assert.New(t)
+	service, _ := CreateCaptionsService()
+	r, _ := http.NewRequest("GET", "/jobs/404", nil)
+	status, _, err := service.GetJob(r)
+	assert.Equal(status, 404)
+	assert.Equal("Job doesn't exist", err.Error())
+}

--- a/service/job_test.go
+++ b/service/job_test.go
@@ -15,7 +15,7 @@ import (
 func TestCreateJob(t *testing.T) {
 	assert := assert.New(t)
 	service, client := createCaptionsService()
-	service.AddProvider(FakeProvider{logger: client.Logger})
+	service.AddProvider(fakeProvider{logger: client.Logger})
 	job := providers.Job{
 		ID:       "123",
 		MediaURL: "http://vp.nyt.com/video.mp4",
@@ -33,7 +33,7 @@ func TestCreateJob(t *testing.T) {
 func TestCreateJobNoMediaURL(t *testing.T) {
 	assert := assert.New(t)
 	service, client := createCaptionsService()
-	service.AddProvider(FakeProvider{logger: client.Logger})
+	service.AddProvider(fakeProvider{logger: client.Logger})
 	job := providers.Job{
 		ID:       "123",
 		Provider: "test-provider",
@@ -50,7 +50,7 @@ func TestCreateJobNoMediaURL(t *testing.T) {
 func TestCreateJobDispatchError(t *testing.T) {
 	assert := assert.New(t)
 	service, client := createCaptionsService()
-	service.AddProvider(BrokenProvider{logger: client.Logger})
+	service.AddProvider(brokenProvider{logger: client.Logger})
 	job := providers.Job{
 		ID:       "123",
 		MediaURL: "http://vp.nyt.com/video.mp4",
@@ -67,7 +67,7 @@ func TestCreateJobDispatchError(t *testing.T) {
 func TestCreateJobInvalidBody(t *testing.T) {
 	assert := assert.New(t)
 	service, client := createCaptionsService()
-	service.AddProvider(FakeProvider{logger: client.Logger})
+	service.AddProvider(fakeProvider{logger: client.Logger})
 	r, _ := http.NewRequest("POST", "/captions", bytes.NewReader([]byte("not json")))
 	status, resultJob, err := service.CreateJob(r)
 	assert.NotNil(err)

--- a/service/service.go
+++ b/service/service.go
@@ -70,10 +70,13 @@ func (s *CaptionsService) Middleware(h http.Handler) http.Handler {
 // Endpoints returns CaptionsService API endpoints
 func (s *CaptionsService) Endpoints() map[string]map[string]http.HandlerFunc {
 	return map[string]map[string]http.HandlerFunc{
+		"/captions/{id}": {
+			"GET": server.JSONToHTTP(s.GetJobs).ServeHTTP,
+		},
 		"/jobs/{id}": {
 			"GET": server.JSONToHTTP(s.GetJob).ServeHTTP,
 		},
-		"/jobs": {
+		"/captions": {
 			"POST": server.JSONToHTTP(s.CreateJob).ServeHTTP,
 		},
 	}

--- a/service/service.go
+++ b/service/service.go
@@ -42,12 +42,11 @@ func NewCaptionsService(cfg *config.CaptionsServiceConfig, db database.DB) *Capt
 	if cfg.Logger == nil {
 		cfg.Logger = logger
 	}
-	logger.Info("healthcheck", cfg.Server.HealthCheckPath)
 	return &CaptionsService{
 		Client{
 			Providers: make(map[string]providers.Provider),
 			DB:        db,
-			logger:    logger,
+			Logger:    logger,
 		},
 	}
 }

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -1,0 +1,66 @@
+package service
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/NYTimes/video-captions-api/database"
+	"github.com/NYTimes/video-captions-api/providers"
+	log "github.com/Sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+)
+
+type FakeProvider struct {
+	logger *log.Logger
+}
+
+func (p FakeProvider) DispatchJob(job providers.Job) (providers.Job, error) {
+	p.logger.Info("dispatching job")
+	return job, nil
+}
+
+func (p FakeProvider) GetJob(id string) (*providers.Job, error) {
+	p.logger.Info("fetching job", id)
+	return &providers.Job{}, nil
+}
+
+func (p FakeProvider) GetName() string {
+	return "test-provider"
+}
+
+type BrokenProvider FakeProvider
+
+func (p BrokenProvider) GetName() string {
+	return "broken-provider"
+}
+
+func (p BrokenProvider) DispatchJob(job providers.Job) (providers.Job, error) {
+	return providers.Job{}, errors.New("provider error")
+}
+
+func (p BrokenProvider) GetJob(id string) (*providers.Job, error) {
+	p.logger.Info("fetching job", id)
+	return nil, errors.New("failed to get job")
+}
+
+func CreateCaptionsService() (*CaptionsService, Client) {
+	client := Client{
+		Providers: make(map[string]providers.Provider),
+		DB:        database.NewMemoryDatabase(),
+		Logger:    log.New(),
+	}
+	service := &CaptionsService{
+		client: client,
+	}
+	return service, client
+}
+
+func TestAddProvider(t *testing.T) {
+	assert := assert.New(t)
+	service, client := CreateCaptionsService()
+
+	service.AddProvider(FakeProvider{})
+	provider := client.Providers["test-provider"]
+	assert.NotNil(provider)
+	assert.Equal(provider.GetName(), "test-provider")
+}

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -43,7 +43,7 @@ func (p BrokenProvider) GetJob(id string) (*providers.Job, error) {
 	return nil, errors.New("failed to get job")
 }
 
-func CreateCaptionsService() (*CaptionsService, Client) {
+func createCaptionsService() (*CaptionsService, Client) {
 	client := Client{
 		Providers: make(map[string]providers.Provider),
 		DB:        database.NewMemoryDatabase(),
@@ -57,7 +57,7 @@ func CreateCaptionsService() (*CaptionsService, Client) {
 
 func TestAddProvider(t *testing.T) {
 	assert := assert.New(t)
-	service, client := CreateCaptionsService()
+	service, client := createCaptionsService()
 
 	service.AddProvider(FakeProvider{})
 	provider := client.Providers["test-provider"]

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -10,35 +10,35 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-type FakeProvider struct {
+type fakeProvider struct {
 	logger *log.Logger
 }
 
-func (p FakeProvider) DispatchJob(job providers.Job) (providers.Job, error) {
+func (p fakeProvider) DispatchJob(job providers.Job) (providers.Job, error) {
 	p.logger.Info("dispatching job")
 	return job, nil
 }
 
-func (p FakeProvider) GetJob(id string) (*providers.Job, error) {
+func (p fakeProvider) GetJob(id string) (*providers.Job, error) {
 	p.logger.Info("fetching job", id)
 	return &providers.Job{}, nil
 }
 
-func (p FakeProvider) GetName() string {
+func (p fakeProvider) GetName() string {
 	return "test-provider"
 }
 
-type BrokenProvider FakeProvider
+type brokenProvider fakeProvider
 
-func (p BrokenProvider) GetName() string {
+func (p brokenProvider) GetName() string {
 	return "broken-provider"
 }
 
-func (p BrokenProvider) DispatchJob(job providers.Job) (providers.Job, error) {
+func (p brokenProvider) DispatchJob(job providers.Job) (providers.Job, error) {
 	return providers.Job{}, errors.New("provider error")
 }
 
-func (p BrokenProvider) GetJob(id string) (*providers.Job, error) {
+func (p brokenProvider) GetJob(id string) (*providers.Job, error) {
 	p.logger.Info("fetching job", id)
 	return nil, errors.New("failed to get job")
 }
@@ -59,7 +59,7 @@ func TestAddProvider(t *testing.T) {
 	assert := assert.New(t)
 	service, client := createCaptionsService()
 
-	service.AddProvider(FakeProvider{})
+	service.AddProvider(fakeProvider{})
 	provider := client.Providers["test-provider"]
 	assert.NotNil(provider)
 	assert.Equal(provider.GetName(), "test-provider")


### PR DESCRIPTION
closes #29 #30 
I changed the routes to be just `POST /captions` `/GET /captions/{parentID}`(for us parentID == scoopID) and just `GET /jobs/{id}` instead of `GET /captions/{parentID}/jobs/{id}`, mostly because we dont need the parentID to get the children so we can treat the job as a single entity. And there is no `POST /job` anymore because we dont want the user to create Jobs without a parent

~~This is missing tests, I'll be adding next but this is good to review already.~~ I'm  testing the [datastore emulator](https://cloud.google.com/datastore/docs/tools/datastore-emulator), to see if its worth to run in drone so we don't need to mock the datastore

EDIT 1: added some tests