### PR TITLE
add docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,9 @@ Run:
 `$ make dev`
 
 Go to http://localhost:8000
+
+## Documentation
+
+For more info check the [docs](https://github.com/NYTimes/video-captions-api/wiki/Home)
+
+


### PR DESCRIPTION
docs are here: https://github.com/NYTimes/video-captions-api/wiki/Home