### PR TITLE
add amara provider

### DIFF
--- a/database/job.go
+++ b/database/job.go
@@ -11,6 +11,7 @@ type ProviderJob struct {
 	ID      string
 	Status  string
 	Details string
+	Params  map[string]string
 }
 
 // Job representation of a captions job

--- a/main.go
+++ b/main.go
@@ -17,10 +17,12 @@ func main() {
 	if err != nil {
 		server.Log.Fatal("Unable to create Datastore client", err)
 	}
-	providerConfig := providers.Load3PlayConfigFromEnv()
+	threeplayConfig := providers.Load3PlayConfigFromEnv()
+	amaraConfig := providers.LoadAmaraConfigFromEnv()
 	captionsService := service.NewCaptionsService(&cfg, db)
 
-	captionsService.AddProvider(providers.New3PlayProvider(&providerConfig, &cfg))
+	captionsService.AddProvider(providers.New3PlayProvider(&threeplayConfig, &cfg))
+	captionsService.AddProvider(providers.NewAmaraProvider(&amaraConfig, &cfg))
 	server.Init("video-captions-api", cfg.Server)
 
 	err = server.Register(captionsService)

--- a/providers/amara.go
+++ b/providers/amara.go
@@ -1,0 +1,111 @@
+package providers
+
+import (
+	"errors"
+	"net/url"
+	"strconv"
+
+	"github.com/NYTimes/amara"
+	"github.com/NYTimes/gizmo/config"
+	captionsConfig "github.com/NYTimes/video-captions-api/config"
+	"github.com/NYTimes/video-captions-api/database"
+	log "github.com/Sirupsen/logrus"
+)
+
+// AmaraProvider amara client wrapper that implements the Provider interface
+type AmaraProvider struct {
+	*amara.Client
+	logger *log.Logger
+}
+
+// AmaraConfig holds Amara related config
+type AmaraConfig struct {
+	Username string `envconfig:"AMARA_USERNAME"`
+	Team     string `envconfig:"AMARA_TEAM"`
+	Token    string `envconfig:"AMARA_TOKEN"`
+}
+
+// NewAmaraProvider creates an AmaraProvider
+func NewAmaraProvider(cfg *AmaraConfig, svcCfg *captionsConfig.CaptionsServiceConfig) Provider {
+	return &AmaraProvider{
+		amara.NewClient(cfg.Username, cfg.Token, cfg.Team),
+		svcCfg.Logger,
+	}
+}
+
+// LoadAmaraConfigFromEnv loads Amara username, token and team from environment
+func LoadAmaraConfigFromEnv() AmaraConfig {
+	var providerConfig AmaraConfig
+	config.LoadEnvConfig(&providerConfig)
+	return providerConfig
+}
+
+// GetName returns provider name
+func (c *AmaraProvider) GetName() string {
+	return "amara"
+}
+
+// Download download latest subtitle version from Amara
+func (c *AmaraProvider) Download(id, _ string) ([]byte, error) {
+	sub, err := c.GetSubtitles(id, "en")
+	if err != nil {
+		return nil, err
+	}
+	return []byte(sub.Subtitles), nil
+}
+
+// GetProviderJob returns current job status from Amara
+func (c *AmaraProvider) GetProviderJob(id string) (*database.ProviderJob, error) {
+	subs, err := c.GetSubtitles(id, "en")
+	status := "in review"
+	if err != nil {
+		return nil, err
+	}
+	lang, err := c.GetLanguage(id, "en")
+	if err != nil {
+		return nil, err
+	}
+
+	if lang.SubtitlesComplete {
+		status = "delivered"
+	}
+
+	return &database.ProviderJob{
+		ID:      id,
+		Status:  status,
+		Details: "Version " + strconv.Itoa(subs.VersionNumber),
+		Params: map[string]string{
+			"SubVersion": strconv.Itoa(subs.VersionNumber),
+		},
+	}, nil
+}
+
+// DispatchJob creates a video and adds subtitle to it
+func (c *AmaraProvider) DispatchJob(job *database.Job) error {
+	params := url.Values{}
+
+	for k, v := range job.ProviderParams {
+		params.Add(k, v)
+	}
+
+	params.Add("team", c.Team)
+	params.Add("video_url", job.MediaURL)
+
+	video, err := c.CreateVideo(params)
+	if err != nil || video.ID == "" {
+		return errors.New("failed to create video in amara")
+	}
+	subs, err := c.CreateSubtitles(video.ID, job.Language, "vtt", params)
+	if err != nil {
+		return err
+	}
+
+	lang, err := c.UpdateLanguage(video.ID, job.Language, false)
+	if err != nil {
+		return err
+	}
+
+	job.ProviderParams["ProviderID"] = video.ID
+	job.ProviderParams["SubVersion"] = strconv.Itoa(subs.VersionNumber)
+	return nil
+}

--- a/providers/amara.go
+++ b/providers/amara.go
@@ -100,7 +100,7 @@ func (c *AmaraProvider) DispatchJob(job *database.Job) error {
 		return err
 	}
 
-	lang, err := c.UpdateLanguage(video.ID, job.Language, false)
+	_, err = c.UpdateLanguage(video.ID, job.Language, false)
 	if err != nil {
 		return err
 	}

--- a/providers/threeplay.go
+++ b/providers/threeplay.go
@@ -46,7 +46,7 @@ func (c *ThreePlayProvider) GetName() string {
 }
 
 // Download downloads captions file from specified type
-func (c *ThreePlayProvider) Download(id string, captionsType string) ([]byte, error) {
+func (c *ThreePlayProvider) Download(id, captionsType string) ([]byte, error) {
 	i, err := strconv.Atoi(id)
 	if err != nil {
 		return nil, err

--- a/service/client.go
+++ b/service/client.go
@@ -56,7 +56,18 @@ func (c Client) GetJob(jobID string) (*database.Job, error) {
 		return nil, err
 	}
 
-	if job.UpdateStatus(providerJob.Status, providerJob.Details) {
+	params := providerJob.Params
+
+	shouldUpdate := false
+
+	for k, v := range params {
+		if params[k] != job.ProviderParams[k] {
+			job.ProviderParams[k] = v
+			shouldUpdate = true
+		}
+	}
+
+	if job.UpdateStatus(providerJob.Status, providerJob.Details) || shouldUpdate {
 		err = c.DB.UpdateJob(jobID, job)
 	}
 

--- a/service/storage.go
+++ b/service/storage.go
@@ -52,5 +52,5 @@ func (gs *GCSStorage) Store(data []byte, filename string) (string, error) {
 		gs.logger.WithError(err).Error("error closing writer ")
 		return "", err
 	}
-	return fmt.Sprintf("https://storage.cloud.google.com/%s/%s", gs.bucketName, objectFullName), nil
+	return fmt.Sprintf("https://storage.googleapis.com/%s/%s", gs.bucketName, objectFullName), nil
 }


### PR DESCRIPTION
to create an amara job:
```
$ curl -vXPOST -d'{"media_url":"https://vp.nyt.com/video.mp4", "parent_id": "4444", "provider": "amara", "provider_params": {"subtitles_url": "https://storage.googleapis.com/video-captions-api-dev/2017/8/21/3play/73576_1_detroit-anatomy_wg_360p.vtt", "sub_format": "vtt"}, "output_types": ["vtt"], "language":"en"}' localhost:8000/captions
```
We want the `media_url` to be the same one as the one we used on 3play, the `subtitles_url` is the output of the 3play job

once the job is created it will look like this:

```
{
  "id": "f9b64fa9-1c27-4439-5470-a3d37ed2864b",
  "parent_id": "4444",
  "media_url": "https://vp.nyt.com/video/2017/08/08/73655_1_opdoc-searching-for-wives_wg_240p.mp4",
  "status": "in review",
  "provider": "amara",
  "provider_params": {
    "ProviderID": "yxKHvQmuNcvv",
    "SubVersion": "1",
    "sub_format": "vtt",
    "subtitles_url": "https://storage.googleapis.com/video-captions-api-dev/2017/8/21/3play/73576_1_detroit-anatomy_wg_360p.vtt"
  },
  "created_at": "2017-08-24T14:21:50.085556-04:00",
  "outputs": [
    {
      "url": "",
      "type": "vtt",
      "filename": "73655_1_opdoc-searching-for-wives_wg_240p.vtt"
    }
  ],
  "done": false,
  "language": "en",
  "details": "Version 1"
}
```
its `status` will stay as `"in review"` until someone goes to https://www.amara.org/en/subtitles/editor/yxKHvQmuNcvv/en/ reviews and publishes it.
The amara job done will be something like:
```
{
  "id": "4e592028-d1ec-4de6-7b16-e9b455a6c960",
  "parent_id": "4444",
  "media_url": "https://vp.nyt.com/video/2017/07/24/73439_1_connecticut-refugees_wg_240p.mp4",
  "status": "delivered",
  "provider": "amara",
  "provider_params": {
    "ProviderID": "zv6SSgMGoNAy",
    "SubVersion": "2",
    "sub_format": "vtt",
    "subtitles_url": "https://storage.googleapis.com/video-captions-api-dev/2017/8/21/3play/73576_1_detroit-anatomy_wg_360p.vtt"
  },
  "created_at": "2017-08-24T16:17:23.354374-04:00",
  "outputs": [
    {
      "url": "https://storage.googleapis.com/video-captions-api-dev/2017/8/24/amara/73439_1_connecticut-refugees_wg_240p.vtt",
      "type": "vtt",
      "filename": "73439_1_connecticut-refugees_wg_240p.vtt"
    }
  ],
  "done": true,
  "language": "en",
  "details": "Version 2"
}
```
where the output vtt is the one that was reviewed/edited in amara

