### PR TITLE
service: improve error handling on GetJob and GetJobs

### DIFF
--- a/database/datastore.go
+++ b/database/datastore.go
@@ -65,7 +65,7 @@ func (d *DatastoreDatabase) GetJob(id string) (*Job, error) {
 	key := newNameKeyWithNamespace(d.kind, id, d.namespace)
 	err := d.client.Get(ctx, key, result)
 	if err == datastore.ErrNoSuchEntity {
-		return nil, errors.New("Job not found")
+		return nil, ErrJobNotFound
 	}
 	if err != nil {
 		return nil, errors.New("Unkown error from Datastore")
@@ -83,7 +83,7 @@ func (d *DatastoreDatabase) GetJobs(parentID string) ([]Job, error) {
 		return nil, errors.New("Unkown error from Datastore")
 	}
 	if len(jobs) == 0 {
-		return nil, errors.New("No Jobs found for this ParentID")
+		return nil, ErrNoJobs
 	}
 	return jobs, nil
 }

--- a/database/datastore_test.go
+++ b/database/datastore_test.go
@@ -83,7 +83,7 @@ func TestGetJob(t *testing.T) {
 	assert.Nil(err)
 
 	_, err = db.GetJob("456")
-	assert.EqualError(err, "Job not found")
+	assert.Equal(err, ErrJobNotFound)
 }
 
 func TestUpdateJob(t *testing.T) {
@@ -107,7 +107,7 @@ func TestUpdateJob(t *testing.T) {
 	assert.Equal(newJob, afterChange)
 
 	err = db.UpdateJob("234", newJob)
-	assert.EqualError(err, "Job not found")
+	assert.Equal(err, ErrJobNotFound)
 }
 
 func TestDeleteJob(t *testing.T) {

--- a/database/db.go
+++ b/database/db.go
@@ -1,5 +1,15 @@
 package database
 
+import "errors"
+
+var (
+	// ErrNoJobs indicates that no jobs can be found for a given parent ID.
+	ErrNoJobs = errors.New("no jobs found with this parent ID")
+
+	// ErrJobNotFound indicates that no job can be found for a given job ID.
+	ErrJobNotFound = errors.New("job not found")
+)
+
 // DB interface for database interactions
 type DB interface {
 	StoreJob(*Job) (string, error)

--- a/database/memory.go
+++ b/database/memory.go
@@ -34,7 +34,7 @@ func (db *MemoryDatabase) StoreJob(job *Job) (string, error) {
 // UpdateJob updates Job in-memory
 func (db *MemoryDatabase) UpdateJob(id string, job *Job) error {
 	if _, err := db.GetJob(id); err != nil {
-		return errors.New("Job doesn't exist")
+		return ErrJobNotFound
 	}
 
 	db.mtx.Lock()
@@ -52,7 +52,7 @@ func (db *MemoryDatabase) GetJob(id string) (*Job, error) {
 	if job, ok := db.jobs[id]; ok {
 		return job, nil
 	}
-	return nil, errors.New("Job doesn't exist")
+	return nil, ErrJobNotFound
 }
 
 // DeleteJob deletes a Job given its ID

--- a/service/client_test.go
+++ b/service/client_test.go
@@ -177,7 +177,7 @@ func TestCancelClientJob404(t *testing.T) {
 
 	canceled, err := client.CancelJob("404")
 	assert.NotNil(err)
-	assert.EqualValues("Job doesn't exist", err.Error())
+	assert.EqualValues("job not found", err.Error())
 	assert.False(canceled)
 }
 
@@ -208,7 +208,7 @@ func TestDownloadNonexistentCaption(t *testing.T) {
 	client.DB.StoreJob(job)
 	_, err := client.DownloadCaption("404", "vtt")
 	assert.NotNil(err)
-	assert.EqualValues("Job doesn't exist", err.Error())
+	assert.EqualValues("job not found", err.Error())
 }
 
 func TestDownloadCaptionProviderError(t *testing.T) {

--- a/service/job_test.go
+++ b/service/job_test.go
@@ -65,7 +65,7 @@ func TestCreateUploadJob(t *testing.T) {
 	service.AddProvider(fakeProvider{logger: client.Logger})
 	job := &database.Job{
 		ID:          "123",
-		CaptionFile: database.UploadedFile{[]byte("captions"), "caption.net"},
+		CaptionFile: database.UploadedFile{File: []byte("captions"), Name: "caption.net"},
 		Provider:    "test-provider",
 	}
 	jobBytes, _ := json.Marshal(job)
@@ -136,7 +136,7 @@ func TestGetJob404(t *testing.T) {
 		t.Errorf("%s: unable to JSON decode response body: %s", w.Body, err)
 	}
 	assert.Equal(w.Code, 404)
-	assert.Equal("Job doesn't exist", jobBody["error"])
+	assert.Equal("job not found", jobBody["error"])
 }
 
 func TestCancelJob(t *testing.T) {
@@ -195,7 +195,7 @@ func TestCancelJob404(t *testing.T) {
 	}
 
 	assert.Equal(w.Code, 404)
-	assert.Equal("Job doesn't exist", cancelBody["error"])
+	assert.Equal("job not found", cancelBody["error"])
 }
 
 func TestCancelJobDone(t *testing.T) {


### PR DESCRIPTION
We only return 404s when the job-id/parent-id doesn't exist. In case
some errors happens internally, we return a 500.