### PR TITLE
Adds job type to providers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ env:
     - GO_FOR_RELEASE=1.x
     - GO111MODULE=on
     - CGO_ENABLED=0
-    - GOPROXY=https://proxy.golang.org
 go:
   - 1.x
 install:

--- a/database/job.go
+++ b/database/job.go
@@ -29,6 +29,7 @@ type Job struct {
 	Language       string         `json:"language"`
 	Details        string         `json:"details,omitempty"`
 	CaptionFile    UploadedFile   `json:"caption_file,omitempty"`
+	JobType        string         `json:"job_type"`
 }
 
 // UploadedFile contains the uploaded file and its name

--- a/database/job.go
+++ b/database/job.go
@@ -77,10 +77,7 @@ func (j *Job) UpdateStatus(status, details string) bool {
 }
 
 func (j *Job) GetProviderID() string {
-	if _, ok := j.ProviderParams["ProviderID"]; ok {
-		return j.ProviderParams["ProviderID"]
-	}
-	return ""
+	return j.ProviderParams["ProviderID"]
 }
 
 // Load makes ProviderParams implement datastore.PropertyLoadSaver interface

--- a/database/job.go
+++ b/database/job.go
@@ -76,6 +76,13 @@ func (j *Job) UpdateStatus(status, details string) bool {
 	return true
 }
 
+func (j *Job) GetProviderID() string {
+	if _, ok := j.ProviderParams["ProviderID"]; ok {
+		return j.ProviderParams["ProviderID"]
+	}
+	return ""
+}
+
 // Load makes ProviderParams implement datastore.PropertyLoadSaver interface
 func (p *ProviderParams) Load(ps []datastore.Property) error {
 	if *p == nil {

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/google/uuid v1.1.1
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/nytimes/amara v0.3.0
-	github.com/nytimes/threeplay v0.3.1
+	github.com/nytimes/threeplay v0.3.2
 	github.com/prometheus/common v0.0.0-20181218105931-67670fe90761 // indirect
 	github.com/sirupsen/logrus v1.4.2
 	github.com/stretchr/testify v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -81,6 +81,7 @@ github.com/golang/protobuf v1.2.0 h1:P3YflyNX/ehuJFLhxviNdFxQPkGK5cDcApsge1SqnvM
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.1 h1:YF8+flBXS5eO826T4nzqPrxfhQThhXl0YzfuUPu4SBg=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
+github.com/golang/protobuf v1.3.2 h1:6nsPYzhq5kReh6QImI3k5qWzO4PEbvbIW2cwSfR/6xs=
 github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/snappy v0.0.0-20180518054509-2e65f85255db/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
@@ -375,6 +376,7 @@ google.golang.org/genproto v0.0.0-20190425155659-357c62f0e4bb/go.mod h1:VzzqZJRn
 google.golang.org/genproto v0.0.0-20190502173448-54afdca5d873/go.mod h1:VzzqZJRnGkLBvHegQrXjBqPurQTc5/KpmUdxsrq26oE=
 google.golang.org/genproto v0.0.0-20190626174449-989357319d63 h1:UsSJe9fhWNSz6emfIGPpH5DF23t7ALo2Pf3sC+/hsdg=
 google.golang.org/genproto v0.0.0-20190626174449-989357319d63/go.mod h1:z3L6/3dTEVtUr6QSP8miRzeRqwQOioJ9I66odjN4I7s=
+google.golang.org/genproto v0.0.0-20190716160619-c506a9f90610 h1:Ygq9/SRJX9+dU0WCIICM8RkWvDw03lvB77hrhJnpxfU=
 google.golang.org/genproto v0.0.0-20190716160619-c506a9f90610/go.mod h1:DMBHOl98Agz4BDEuKkezgsaosCRResVns1a3J2ZsMNc=
 google.golang.org/grpc v1.12.0/go.mod h1:yo6s7OP7yaDglbqo1J04qKzAhqBH6lvTonzMVmEdcZw=
 google.golang.org/grpc v1.14.0 h1:ArxJuB1NWfPY6r9Gp9gqwplT0Ge7nqv9msgu03lHLmo=

--- a/go.sum
+++ b/go.sum
@@ -160,6 +160,8 @@ github.com/nytimes/threeplay v0.3.0 h1:KNRBzlhfGCjpw8mCeHSTyHpafh1CO2tUv2LTnKvgM
 github.com/nytimes/threeplay v0.3.0/go.mod h1:7Ttlufr7v1zBWMJ3BgyNP/FU/bReMX2cWzQByXMAijU=
 github.com/nytimes/threeplay v0.3.1 h1:Q4Y/5zd1gWQScEqbaLCWf374uwCPL1s3vCAevotEvDc=
 github.com/nytimes/threeplay v0.3.1/go.mod h1:7RYQwk6M28F77xLPmzb0DAe7fBmdLD3MAFvXrF7Q2us=
+github.com/nytimes/threeplay v0.3.2 h1:vJNX/g6i+U012rKOYVWICKCY1JLBLkmTwcgAXIouhSw=
+github.com/nytimes/threeplay v0.3.2/go.mod h1:7RYQwk6M28F77xLPmzb0DAe7fBmdLD3MAFvXrF7Q2us=
 github.com/openzipkin/zipkin-go v0.1.1/go.mod h1:NtoC/o8u3JlF1lSlyPNswIbeQH9bJTmOf0Erfk+hxe8=
 github.com/openzipkin/zipkin-go v0.1.3/go.mod h1:NtoC/o8u3JlF1lSlyPNswIbeQH9bJTmOf0Erfk+hxe8=
 github.com/pierrec/lz4 v2.0.5+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=

--- a/providers/amara.go
+++ b/providers/amara.go
@@ -51,7 +51,7 @@ func (c *AmaraProvider) GetName() string {
 
 // Download download latest subtitle version from Amara
 func (c *AmaraProvider) Download(job *database.Job, captionFormat string) ([]byte, error) {
-	sub, err := c.GetRawSubtitles(job.ProviderParams["ProviderID"], "en", captionFormat)
+	sub, err := c.GetRawSubtitles(job.GetProviderID(), "en", captionFormat)
 	if err != nil {
 		return nil, err
 	}
@@ -60,12 +60,12 @@ func (c *AmaraProvider) Download(job *database.Job, captionFormat string) ([]byt
 
 // GetProviderJob returns current job status from Amara
 func (c *AmaraProvider) GetProviderJob(job *database.Job) (*database.ProviderJob, error) {
-	subs, err := c.GetSubtitleInfo(job.ProviderParams["ProviderID"], "en")
+	subs, err := c.GetSubtitleInfo(job.GetProviderID(), "en")
 	status := "in review"
 	if err != nil {
 		return nil, err
 	}
-	lang, err := c.GetLanguage(job.ProviderParams["ProviderID"], "en")
+	lang, err := c.GetLanguage(job.GetProviderID(), "en")
 	if err != nil {
 		return nil, err
 	}
@@ -75,7 +75,7 @@ func (c *AmaraProvider) GetProviderJob(job *database.Job) (*database.ProviderJob
 	}
 
 	return &database.ProviderJob{
-		ID:      job.ProviderParams["ProviderID"],
+		ID:      job.GetProviderID(),
 		Status:  status,
 		Details: "Version " + strconv.Itoa(subs.VersionNumber),
 		Params: map[string]string{

--- a/providers/amara.go
+++ b/providers/amara.go
@@ -50,8 +50,8 @@ func (c *AmaraProvider) GetName() string {
 }
 
 // Download download latest subtitle version from Amara
-func (c *AmaraProvider) Download(id, captionFormat string) ([]byte, error) {
-	sub, err := c.GetRawSubtitles(id, "en", captionFormat)
+func (c *AmaraProvider) Download(job *database.Job, captionFormat string) ([]byte, error) {
+	sub, err := c.GetRawSubtitles(job.ProviderParams["ProviderID"], "en", captionFormat)
 	if err != nil {
 		return nil, err
 	}
@@ -59,13 +59,13 @@ func (c *AmaraProvider) Download(id, captionFormat string) ([]byte, error) {
 }
 
 // GetProviderJob returns current job status from Amara
-func (c *AmaraProvider) GetProviderJob(id string) (*database.ProviderJob, error) {
-	subs, err := c.GetSubtitleInfo(id, "en")
+func (c *AmaraProvider) GetProviderJob(job *database.Job) (*database.ProviderJob, error) {
+	subs, err := c.GetSubtitleInfo(job.ProviderParams["ProviderID"], "en")
 	status := "in review"
 	if err != nil {
 		return nil, err
 	}
-	lang, err := c.GetLanguage(id, "en")
+	lang, err := c.GetLanguage(job.ProviderParams["ProviderID"], "en")
 	if err != nil {
 		return nil, err
 	}
@@ -75,7 +75,7 @@ func (c *AmaraProvider) GetProviderJob(id string) (*database.ProviderJob, error)
 	}
 
 	return &database.ProviderJob{
-		ID:      id,
+		ID:      job.ProviderParams["ProviderID"],
 		Status:  status,
 		Details: "Version " + strconv.Itoa(subs.VersionNumber),
 		Params: map[string]string{
@@ -127,6 +127,6 @@ func (c *AmaraProvider) DispatchJob(job *database.Job) error {
 }
 
 // CancelJob dummy method as amara cannot cancel jobs
-func (c *AmaraProvider) CancelJob(id string) (bool, error) {
+func (c *AmaraProvider) CancelJob(job *database.Job) (bool, error) {
 	return false, nil
 }

--- a/providers/provider.go
+++ b/providers/provider.go
@@ -5,8 +5,8 @@ import "github.com/NYTimes/video-captions-api/database"
 // Provider is the interface that transcription/captions providers must implement
 type Provider interface {
 	DispatchJob(*database.Job) error
-	Download(id string, captionsType string) ([]byte, error)
-	GetProviderJob(id string) (*database.ProviderJob, error)
+	Download(*database.Job, string) ([]byte, error)
+	GetProviderJob(*database.Job) (*database.ProviderJob, error)
 	GetName() string
-	CancelJob(id string) (bool, error)
+	CancelJob(*database.Job) (bool, error)
 }

--- a/providers/threeplay.go
+++ b/providers/threeplay.go
@@ -81,7 +81,7 @@ func (c *ThreePlayProvider) DispatchJob(job *database.Job) error {
 	jobLogger := c.logger.WithFields(log.Fields{"JobID": job.ID, "Provider": job.Provider})
 	callParams := threeplay.CallParams{APIKey: c.config.APIKeyByJobType[job.JobType]}
 	// Review job route
-	if mediaFileID, ok := job.ProviderParams["media_file_id"]; ok {
+	if providerID, ok := job.ProviderParams["provider_id"]; ok {
 		hoursInt := 2
 		var err error
 		if hoursUntilExpiration, ok := job.ProviderParams["hours_until_expiration"]; ok {
@@ -90,13 +90,13 @@ func (c *ThreePlayProvider) DispatchJob(job *database.Job) error {
 				jobLogger.WithError(err).Error("Could not convert hours until expiration")
 			}
 		}
-		reviewURL, err := c.GetEditingLink(mediaFileID, hoursInt, callParams)
+		reviewURL, err := c.GetEditingLink(providerID, hoursInt, callParams)
 		if err != nil {
 			jobLogger.WithError(err).Error("Could not generate review url")
 			return err
 		}
 
-		job.ProviderParams["ProviderID"] = mediaFileID
+		job.ProviderParams["ProviderID"] = providerID
 		job.ProviderParams["ReviewURL"] = reviewURL
 		return nil
 	}

--- a/providers/upload.go
+++ b/providers/upload.go
@@ -29,7 +29,7 @@ func (c *UploadProvider) GetName() string {
 
 // Download returns the uploaded caption file
 func (c *UploadProvider) Download(job *database.Job, captionsType string) ([]byte, error) {
-	job, err := c.DB.GetJob(job.ProviderParams["ProviderID"])
+	job, err := c.DB.GetJob(job.GetProviderID())
 	if err != nil {
 		return nil, fmt.Errorf("could not find job in DB")
 	}
@@ -38,12 +38,12 @@ func (c *UploadProvider) Download(job *database.Job, captionsType string) ([]byt
 
 // GetProviderJob returns the provider's job parameters.
 func (c *UploadProvider) GetProviderJob(job *database.Job) (*database.ProviderJob, error) {
-	job, err := c.DB.GetJob(job.ProviderParams["ProviderID"])
+	job, err := c.DB.GetJob(job.GetProviderID())
 	if err != nil {
 		return nil, fmt.Errorf("could not find job in DB")
 	}
 	providerJob := &database.ProviderJob{
-		ID:      job.ProviderParams["ProviderID"],
+		ID:      job.GetProviderID(),
 		Status:  job.ProviderParams["status"],
 		Details: job.ProviderParams["details"],
 	}

--- a/providers/upload.go
+++ b/providers/upload.go
@@ -28,8 +28,8 @@ func (c *UploadProvider) GetName() string {
 }
 
 // Download returns the uploaded caption file
-func (c *UploadProvider) Download(id string, captionsType string) ([]byte, error) {
-	job, err := c.DB.GetJob(id)
+func (c *UploadProvider) Download(job *database.Job, captionsType string) ([]byte, error) {
+	job, err := c.DB.GetJob(job.ProviderParams["ProviderID"])
 	if err != nil {
 		return nil, fmt.Errorf("could not find job in DB")
 	}
@@ -37,8 +37,8 @@ func (c *UploadProvider) Download(id string, captionsType string) ([]byte, error
 }
 
 // GetProviderJob returns the provider's job parameters.
-func (c *UploadProvider) GetProviderJob(id string) (*database.ProviderJob, error) {
-	job, err := c.DB.GetJob(id)
+func (c *UploadProvider) GetProviderJob(job *database.Job) (*database.ProviderJob, error) {
+	job, err := c.DB.GetJob(job.ProviderParams["ProviderID"])
 	if err != nil {
 		return nil, fmt.Errorf("could not find job in DB")
 	}
@@ -62,6 +62,6 @@ func (c *UploadProvider) DispatchJob(job *database.Job) error {
 	return nil
 }
 
-func (c *UploadProvider) CancelJob(id string) (bool, error) {
+func (c *UploadProvider) CancelJob(job *database.Job) (bool, error) {
 	return false, nil
 }

--- a/service/client.go
+++ b/service/client.go
@@ -57,7 +57,7 @@ func (c Client) GetJob(jobID string) (*database.Job, error) {
 	jobLogger := c.Logger.WithFields(fields)
 	provider := c.Providers[job.Provider]
 	jobLogger.Info("Fetching job from Provider")
-	providerJob, err := provider.GetProviderJob(providerID)
+	providerJob, err := provider.GetProviderJob(job)
 	if err != nil {
 		jobLogger.Error("error getting job from provider", err)
 		return nil, err
@@ -81,7 +81,7 @@ func (c Client) GetJob(jobID string) (*database.Job, error) {
 	if (job.Status == "complete" || job.Status == "delivered") && !job.Done {
 		jobLogger.Info("Job is ready on the provider, downloading")
 		for i, output := range job.Outputs {
-			data, err := provider.Download(providerID, output.Type)
+			data, err := provider.Download(job, output.Type)
 			if err != nil {
 				jobLogger.WithError(err).Error("Failed to download file")
 				return job, nil
@@ -143,7 +143,7 @@ func (c Client) CancelJob(jobID string) (bool, error) {
 	err = c.DB.UpdateJob(jobID, job)
 	c.Logger.Info("Cancelled job in the database")
 	if job.Provider == "3play" {
-		cancellable, err := c.Providers[job.Provider].CancelJob(job.ProviderParams["ProviderID"])
+		cancellable, err := c.Providers[job.Provider].CancelJob(job)
 		if err != nil {
 			if cancellable {
 				c.Logger.Errorf("Could not cancel job with 3play but set to cancel in DB: %v", err)
@@ -171,7 +171,7 @@ func (c Client) DownloadCaption(jobID string, captionType string) ([]byte, error
 	jobLogger := c.Logger.WithFields(fields)
 	provider := c.Providers[job.Provider]
 	jobLogger.Info("Downloading captions from provider")
-	captions, err := provider.Download(providerID, captionType)
+	captions, err := provider.Download(job, captionType)
 	if err != nil {
 		jobLogger.Error("error downloading captions from provider", err)
 		return nil, err
@@ -262,7 +262,11 @@ func (c Client) GenerateTranscript(captionFile []byte, captionFormat string) (st
 }
 
 func (c Client) ProcessCallback(callbackData CallbackData, jobID string) error {
-	jobLogger := c.Logger
+	jobLogger := c.Logger.WithFields(log.Fields{
+		"JobID":      jobID,
+		"ProviderID": callbackData.ID,
+		"Status":     callbackData.Status,
+	})
 	jobLogger.Info("Processing a callback for captions")
 	if callbackData.ID == 0 {
 		jobLogger.Error("Invalid Provider ID")

--- a/service/client.go
+++ b/service/client.go
@@ -52,7 +52,7 @@ func (c Client) GetJob(jobID string) (*database.Job, error) {
 		return job, nil
 	}
 
-	providerID := job.ProviderParams["ProviderID"]
+	providerID := job.GetProviderID()
 	fields := log.Fields{"JobID": jobID, "Provider": job.Provider, "ProviderID": providerID}
 	jobLogger := c.Logger.WithFields(fields)
 	provider := c.Providers[job.Provider]
@@ -166,7 +166,7 @@ func (c Client) DownloadCaption(jobID string, captionType string) ([]byte, error
 		return nil, err
 	}
 
-	providerID := job.ProviderParams["ProviderID"]
+	providerID := job.GetProviderID()
 	fields := log.Fields{"JobID": jobID, "Provider": job.Provider, "ProviderID": providerID}
 	jobLogger := c.Logger.WithFields(fields)
 	provider := c.Providers[job.Provider]

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -54,7 +54,7 @@ func (p fakeProvider) GetProviderJob(job *database.Job) (*database.ProviderJob, 
 		}
 		return job, nil
 	}
-	p.logger.Info("fetching job", job.ProviderParams["ProviderID"])
+	p.logger.Info("fetching job", job.GetProviderID())
 	return &database.ProviderJob{}, nil
 }
 
@@ -62,7 +62,7 @@ func (p fakeProvider) GetName() string {
 	return "test-provider"
 }
 
-func (p fakeProvider) CancelJob(ijob *database.Job) (bool, error) {
+func (p fakeProvider) CancelJob(job *database.Job) (bool, error) {
 	return true, nil
 }
 
@@ -81,7 +81,7 @@ func (p brokenProvider) DispatchJob(job *database.Job) error {
 }
 
 func (p brokenProvider) GetProviderJob(job *database.Job) (*database.ProviderJob, error) {
-	p.logger.Info("fetching job", job.ProviderParams["ProviderID"])
+	p.logger.Info("fetching job", job.GetProviderID())
 	return nil, errors.New("failed to get job")
 }
 

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -25,7 +25,7 @@ func (p fakeProvider) DispatchJob(job *database.Job) error {
 	return nil
 }
 
-func (p fakeProvider) Download(_ string, captionType string) ([]byte, error) {
+func (p fakeProvider) Download(_ *database.Job, captionType string) ([]byte, error) {
 	switch captionType {
 	case "vtt":
 		return []byte("WEBVTT\n\nNOTE Paragraph\n\n00:00:09.240 --> 00:00:11.010\nWe're all talking\nabout the Iowa caucuses"), nil
@@ -40,7 +40,7 @@ func (p fakeProvider) Download(_ string, captionType string) ([]byte, error) {
 	}
 }
 
-func (p fakeProvider) GetProviderJob(id string) (*database.ProviderJob, error) {
+func (p fakeProvider) GetProviderJob(job *database.Job) (*database.ProviderJob, error) {
 	if p.params["jobError"] {
 		return nil, errors.New("oh no")
 	}
@@ -54,7 +54,7 @@ func (p fakeProvider) GetProviderJob(id string) (*database.ProviderJob, error) {
 		}
 		return job, nil
 	}
-	p.logger.Info("fetching job", id)
+	p.logger.Info("fetching job", job.ProviderParams["ProviderID"])
 	return &database.ProviderJob{}, nil
 }
 
@@ -62,7 +62,7 @@ func (p fakeProvider) GetName() string {
 	return "test-provider"
 }
 
-func (p fakeProvider) CancelJob(id string) (bool, error) {
+func (p fakeProvider) CancelJob(ijob *database.Job) (bool, error) {
 	return true, nil
 }
 
@@ -72,7 +72,7 @@ func (p brokenProvider) GetName() string {
 	return "broken-provider"
 }
 
-func (p brokenProvider) Download(_ string, _ string) ([]byte, error) {
+func (p brokenProvider) Download(_ *database.Job, _ string) ([]byte, error) {
 	return nil, errors.New("download error")
 }
 
@@ -80,12 +80,12 @@ func (p brokenProvider) DispatchJob(job *database.Job) error {
 	return errors.New("provider error")
 }
 
-func (p brokenProvider) GetProviderJob(id string) (*database.ProviderJob, error) {
-	p.logger.Info("fetching job", id)
+func (p brokenProvider) GetProviderJob(job *database.Job) (*database.ProviderJob, error) {
+	p.logger.Info("fetching job", job.ProviderParams["ProviderID"])
 	return nil, errors.New("failed to get job")
 }
 
-func (p brokenProvider) CancelJob(id string) (bool, error) {
+func (p brokenProvider) CancelJob(job *database.Job) (bool, error) {
 	return false, nil
 }
 


### PR DESCRIPTION
I tried to make this change in the least intrusive way possible - 
The 3Play API key env config is now a map that has an api key for each job type.
The 3Play provider now gets a whole job object, from which it extracts the fields it previously needed to make the calls, and now also the job type, which it uses as a key to the api-key map.
The provider interface was changed to facilitate the passing of the whole job object, but the functionality of the upload and amara providers did not change.

This PR would not build successfully until the 3Play change is merged, and we should not merge/deploy this before updating the secrets in vault.