### PR TITLE
ignore lint errors recently added to golangci-lint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ install-golangcilint:
 	GO111MODULE=off go get github.com/golangci/golangci-lint/cmd/golangci-lint
 
 run-lint:
-	golangci-lint run --enable-all -D errcheck -D lll --deadline 5m ./...
+	golangci-lint run --enable-all -D errcheck -D lll -D funlen -D wsl --deadline 5m ./...
 
 lint: install-golangcilint run-lint
 

--- a/providers/threeplay.go
+++ b/providers/threeplay.go
@@ -77,7 +77,6 @@ func (c *ThreePlayProvider) GetProviderJob(job *database.Job) (*database.Provide
 
 // DispatchJob sends a video file to 3play for transcription and captions generation or generates a expiring editing link
 // when the media_file_url param is provided
-//nolint:funlen
 func (c *ThreePlayProvider) DispatchJob(job *database.Job) error {
 	jobLogger := c.logger.WithFields(log.Fields{"JobID": job.ID, "Provider": job.Provider})
 	callParams := threeplay.CallParams{APIKey: c.config.APIKeyByJobType[job.JobType]}

--- a/service/client.go
+++ b/service/client.go
@@ -179,7 +179,6 @@ func (c Client) DownloadCaption(jobID string, captionType string) ([]byte, error
 }
 
 // GenerateTranscript generates a transcript from the provided caption file and format
-//nolint:funlen
 func (c Client) GenerateTranscript(captionFile []byte, captionFormat string) (string, error) {
 	fields := log.Fields{"captionFormat": captionFormat}
 	jobLogger := c.Logger.WithFields(fields)

--- a/service/client_test.go
+++ b/service/client_test.go
@@ -322,7 +322,6 @@ type processCallbackClientTest struct {
 	serverResponse  int
 }
 
-//nolint:funlen
 func TestProcessCallbackClient(t *testing.T) {
 	tests := []processCallbackClientTest{
 		{

--- a/service/job_test.go
+++ b/service/job_test.go
@@ -349,7 +349,6 @@ type processCallbackTest struct {
 	startFakeServer bool
 }
 
-//nolint:funlen
 func TestProcessCallback(t *testing.T) {
 	tests := []processCallbackTest{
 		{


### PR DESCRIPTION
This should fix the build for the time being. We should consider using `golint` and `go vet` in the future.