### PR TITLE
pass tag to goreleaser script for linter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ env:
 go:
   - 1.x
 install:
-  - curl https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | BINDIR=$GOPATH/bin sh
+  - curl https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | BINDIR=$GOPATH/bin sh -s v1.21.0
   - go mod download
 script:
   - make run-lint coverage


### PR DESCRIPTION
This PR pins our usage of golangci-lint to https://github.com/golangci/golangci-lint/releases/tag/v1.21.0 so we can have a passing build while working on making this code compliant with v1.22