### PR TITLE
Run as non-root user in Dockerfile

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -6,4 +6,9 @@ FROM alpine:3.11.6
 RUN apk add --no-cache ca-certificates
 ADD video-captions-api /bin/captions-api
 
+RUN chmod a+x /bin/captions-api
+
+RUN addgroup service && adduser -DH -G service service
+USER service
+
 ENTRYPOINT ["/bin/captions-api"]


### PR DESCRIPTION
To help mitigate the risk of container breakout as well as adhere to [Docker best practices](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#user). This PR setups a non-root user for the service to run as.