### PR TITLE
use new Drone CLI version and new syntax

### DIFF
--- a/travis-scripts/deploy.bash
+++ b/travis-scripts/deploy.bash
@@ -2,7 +2,7 @@
 
 # This script triggers the deployment through a remote Drone server.
 
-DRONE_VERSION=v0.8.1
+DRONE_VERSION=v1.2.2
 
 function install_drone() {
 	version=$1
@@ -26,7 +26,7 @@ function main() {
 
 	install_drone $DRONE_VERSION
 	last_build=$(drone build last --format "{{.Number}}" $DRONE_REPO)
-	drone deploy -p IMAGE=nytimes/video-captions-api:${image_tag} $DRONE_REPO $last_build $env
+	drone build promote -p IMAGE=nytimes/video-captions-api:${image_tag} $DRONE_REPO $last_build $env
 }
 
 main "$@"


### PR DESCRIPTION
Ticket: https://jira.nyt.net/browse/MULT-2143

This was an oversight to not include captions-api in work related to upgrades of the NYT Drone server, since this repo uses Travis for its CI.

However, the `drone deploy` command, run from v0.x of the Drone CLI doesn't work with servers running versions 1.x. This PR updates both the version of the CLI and updates the deploy script to use the new `drone build promote` syntax.