### PR TITLE
Fix docker release tags

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -60,10 +60,25 @@ steps:
       from_secret: docker_password
     tags:
       - ${DRONE_COMMIT_SHA:0:8}
-      - ${DRONE_TAG}
   when:
     event:
       - push
+    branch:
+      - main
+- name: docker-release
+  image: plugins/docker
+  settings:
+    repo: nytimes/video-captions-api
+    auto_tag: false
+    username:
+      from_secret: docker_username
+    password:
+      from_secret: docker_password
+    tags:
+      - latest
+      - ${DRONE_TAG}
+  when:
+    event:
       - tag
     branch:
       - main


### PR DESCRIPTION
To enable a properly version tagged docker image, we must break the tag docker image build into it's own step
